### PR TITLE
fix: disable code transform when resolvedExternals is empty

### DIFF
--- a/.changeset/sweet-grapes-drum.md
+++ b/.changeset/sweet-grapes-drum.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-externalize-dependencies": minor
+---
+
+Fix the case when no externals are matched

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-externalize-dependencies",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-externalize-dependencies",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.26.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,9 @@ const esbuildPluginExternalize = (
 const modulePrefixTransform = (): Plugin => ({
   name: "vite-plugin-remove-prefix",
   transform: (code: string): string => {
+    // Verify if there are any external modules resolved to avoid having /\/@id\/()/g regex
+    if (resolvedExternals.size === 0) return code;
+
     const viteImportAnalysisModulePrefix = "/@id/";
     const prefixedImportRegex = new RegExp(
       `${viteImportAnalysisModulePrefix}(${[...resolvedExternals].join("|")})`,


### PR DESCRIPTION
This PR should fix https://github.com/MilanKovacic/vite-plugin-externalize-dependencies/issues/108