### PR TITLE
Handle base path

### DIFF
--- a/.changeset/clean-snakes-fail.md
+++ b/.changeset/clean-snakes-fail.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-externalize-dependencies": major
+---
+
+Account for vite's base path config

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,9 @@ const modulePrefixTransform = ({
 
     const viteImportAnalysisModulePrefix = "@id/";
     const prefixedImportRegex = new RegExp(
-      `${base}${viteImportAnalysisModulePrefix}(${[...resolvedExternals].join("|")})`,
+      `${base}${viteImportAnalysisModulePrefix}(${[...resolvedExternals].join(
+        "|",
+      )})`,
       "g",
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ const esbuildPluginExternalize = (
  * Creates a plugin to remove prefix from imports injected by Vite.
  * If module is externalized, Vite will prefix imports with "/\@id/" during development.
  *
- * @param externals - The list of external modules
+ * @param config.base - The base path of the vite configuration
  *
  * @returns Vite plugin to remove prefix from imports
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,15 +72,15 @@ const esbuildPluginExternalize = (
  *
  * @returns Vite plugin to remove prefix from imports
  */
-const modulePrefixTransform = (): Plugin => ({
+const modulePrefixTransform = ({ base }: { base: string }): Plugin => ({
   name: "vite-plugin-remove-prefix",
   transform: (code: string): string => {
     // Verify if there are any external modules resolved to avoid having /\/@id\/()/g regex
     if (resolvedExternals.size === 0) return code;
 
-    const viteImportAnalysisModulePrefix = "/@id/";
+    const viteImportAnalysisModulePrefix = "@id/";
     const prefixedImportRegex = new RegExp(
-      `${viteImportAnalysisModulePrefix}(${[...resolvedExternals].join("|")})`,
+      `${base}${viteImportAnalysisModulePrefix}(${[...resolvedExternals].join("|")})`,
       "g",
     );
 
@@ -137,7 +137,9 @@ const vitePluginExternalize = (options: PluginOptions): Plugin => ({
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    resolvedConfig.plugins.push(modulePrefixTransform());
+    resolvedConfig.plugins.push(
+      modulePrefixTransform({ base: resolvedConfig.base ?? "/" }),
+    );
   },
   // Supresses the following warning:
   // Failed to resolve import [dependency] from [sourceFile]. Does the file exist?

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ import { Plugin as EsbuildPlugin, PluginBuild, OnResolveArgs } from "esbuild";
 
 type ExternalCriteria = string | RegExp | ((id: string) => boolean);
 
+interface ModulePrefixTransformPluginOptions {
+  /** The base path of the vite configuration */
+  base: string;
+}
+
 interface PluginOptions {
   externals: ExternalCriteria[];
 }
@@ -68,11 +73,13 @@ const esbuildPluginExternalize = (
  * Creates a plugin to remove prefix from imports injected by Vite.
  * If module is externalized, Vite will prefix imports with "/\@id/" during development.
  *
- * @param config.base - The base path of the vite configuration
+ * @param options - The plugin options
  *
  * @returns Vite plugin to remove prefix from imports
  */
-const modulePrefixTransform = ({ base }: { base: string }): Plugin => ({
+const modulePrefixTransform = ({
+  base,
+}: ModulePrefixTransformPluginOptions): Plugin => ({
   name: "vite-plugin-remove-prefix",
   transform: (code: string): string => {
     // Verify if there are any external modules resolved to avoid having /\/@id\/()/g regex


### PR DESCRIPTION
This PR adds support for projects that uses the `base` setting. We simply modify the RegExp and add the path to the match pattern.

This fix is also described in this comment here:
https://github.com/vitejs/vite/issues/6582#issuecomment-2112466813