### PR TITLE
Get it to work for dependencies inside node_modules

### DIFF
--- a/.changeset/lemon-pillows-sneeze.md
+++ b/.changeset/lemon-pillows-sneeze.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-externalize-dependencies": patch
+---
+
+Externalize dependencies inside node_modules

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,10 +42,21 @@ const esbuildPluginExternalize = (
 ): EsbuildPlugin => ({
   name: "externalize",
   setup(build: PluginBuild) {
-    // Supresses the following error:
-    // The entry point [moduleName] cannot be marked as external
     build.onResolve({ filter: /.*/ }, (args: OnResolveArgs) => {
-      if (isExternal(args.path, externals)) {
+      if (
+        isExternal(args.path, externals) &&
+        args.kind === "import-statement"
+      ) {
+        resolvedExternals.add(args.path);
+        return {
+          path: args.path,
+          external: true,
+        };
+      }
+
+      // Supresses the following error:
+      // The entry point [moduleName] cannot be marked as external
+      if (isExternal(args.path, externals) && args.kind === "entry-point") {
         resolvedExternals.add(args.path);
         return { path: args.path, namespace: "externalized-modules" };
       }


### PR DESCRIPTION
I had an issue getting this to work where dependencies inside my node_modules were still transformed into something different. In fact, it seemed to be transformed into an empty content during pre-bundling.

Eg:
Say I want to externalize package X. If package Y in my node_modules uses X, it broke the code.

I added an extra check only for `import-statement` and set it to external. This seems to have done the job for me. Admittedly, I'm not the most familiar with bundlers so I might've missed something. Do let me know!