### PR TITLE
fix: duplicate esbuild plugins

### DIFF
--- a/.changeset/curvy-jokes-shave.md
+++ b/.changeset/curvy-jokes-shave.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-externalize-dependencies": patch
+---
+
+fix duplicated esbuild plugins issue

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,27 +128,23 @@ const vitePluginExternalize = (options: PluginOptions): Plugin => ({
   name: "vite-plugin-externalize",
   enforce: "pre",
   apply: "serve",
-  config: (config: UserConfig): UserConfig | undefined => {
-    const modifiedConfiguration = { ...config };
-
-    modifiedConfiguration.optimizeDeps ??= {};
-    modifiedConfiguration.optimizeDeps.esbuildOptions ??= {};
-    modifiedConfiguration.optimizeDeps.esbuildOptions.plugins ??= [];
+  config: (config: UserConfig): Omit<UserConfig, "plugins"> | null | void => {
+    config.optimizeDeps ??= {}; // eslint-disable-line no-param-reassign
+    config.optimizeDeps.esbuildOptions ??= {}; // eslint-disable-line no-param-reassign
+    config.optimizeDeps.esbuildOptions.plugins ??= []; // eslint-disable-line no-param-reassign
 
     // Prevent the plugin from being inserted multiple times
     const pluginName = "externalize";
-    const isPluginAdded =
-      modifiedConfiguration.optimizeDeps.esbuildOptions.plugins.some(
-        (plugin) => plugin.name === pluginName,
-      );
+    const isPluginAdded = config.optimizeDeps.esbuildOptions.plugins.some(
+      (plugin: EsbuildPlugin) => plugin.name === pluginName,
+    );
 
     if (!isPluginAdded) {
-      modifiedConfiguration.optimizeDeps.esbuildOptions.plugins.push(
+      config.optimizeDeps.esbuildOptions.plugins.push(
         esbuildPluginExternalize(options.externals),
       );
     }
-
-    return modifiedConfiguration;
+    return null;
   },
   configResolved: (resolvedConfig: ResolvedConfig) => {
     // Plugins are read-only, and should not be modified,


### PR DESCRIPTION
According to [vite plug api](https://vitejs.dev/guide/api-plugin.html#config), `config` function hook `can return a partial config object that will be deeply merged into existing config,`

So, `config` funciton in `vite-plugin-externalize` should not return modifiedConfig,  otherwise `esbuilsOptions.pluins` will merged with original array, results in duplication.

simplely tested in configResolved phase:
```
  configResolved: (resolvedConfig: ResolvedConfig) => {
    console.table(resolvedConfig.optimizeDeps.esbuildOptions.plugins)
  }
```
